### PR TITLE
add flag to set custom values via CLI

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,4 +13,5 @@ require (
 	github.com/spf13/cobra v0.0.5
 	github.com/tcnksm/go-gitconfig v0.1.2
 	gopkg.in/src-d/go-git.v4 v4.13.1
+	helm.sh/helm v2.16.1+incompatible
 )

--- a/go.sum
+++ b/go.sum
@@ -145,3 +145,5 @@ gopkg.in/warnings.v0 v0.1.2/go.mod h1:jksf8JmL6Qr/oQM2OXTHunEvvTAsrWBLb6OOjuVWRN
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+helm.sh/helm v2.16.1+incompatible h1:np11uYeEtlYcFIFRya8Xs5ZweV1z6MvaWQqJAW+1SZQ=
+helm.sh/helm v2.16.1+incompatible/go.mod h1:0Xbc6ErzwWH9qC55X1+hE3ZwhM3atbhCm/NbFZw5i+4=


### PR DESCRIPTION
This uses the helm string value parser to parse nested raw string kv
pairs into a `map[string]interface{}`.