### PR TITLE
support use of optional per-skeleton config file

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -21,6 +21,8 @@ const (
 var (
 	DefaultSkeletonsDir = configdir.LocalConfig("skeleton-go", "skeletons")
 	DefaultConfigPath   = configdir.LocalConfig("skeleton-go", "config.yaml")
+
+	SkeletonConfigFile = ".skeleton-go.yaml"
 )
 
 type Config struct {

--- a/pkg/template/functions.go
+++ b/pkg/template/functions.go
@@ -1,0 +1,30 @@
+package template
+
+import (
+	"text/template"
+
+	"github.com/ghodss/yaml"
+)
+
+var funcMap = template.FuncMap{
+	"toYAML":     toYAML,
+	"mustToYAML": mustToYAML,
+
+	// For compatibility with the naming helm users are used to.
+	"toYaml":     toYAML,
+	"mustToYaml": mustToYAML,
+}
+
+func toYAML(data interface{}) string {
+	s, _ := mustToYAML(data)
+	return s
+}
+
+func mustToYAML(data interface{}) (string, error) {
+	buf, err := yaml.Marshal(data)
+	if err != nil {
+		return "", err
+	}
+
+	return string(buf), nil
+}

--- a/pkg/template/render.go
+++ b/pkg/template/render.go
@@ -16,6 +16,7 @@ func Render(file string, data interface{}) ([]byte, error) {
 	tpl, err := template.New(name).
 		Option("missingkey=error").
 		Funcs(sprig.TxtFuncMap()).
+		Funcs(funcMap).
 		ParseFiles(file)
 	if err != nil {
 		return nil, fmt.Errorf("failed to prepare template: %v", err)


### PR DESCRIPTION
This also adds the `toYAML` and `mustToYAML` template functions.